### PR TITLE
Add Empire Conf to the schedule for October 2017

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ You can find a list of events in 2016 [here](https://github.com/prigara/javascri
 | [NCDevCon](http://www.ncdevcon.com/) | October 7-8, 2017 | | Raleigh, NC, USA |
 | [Angular Mix](https://angularmix.com) | October 10-11, 2017 | | Orlando, FL, USA |
 | [EmberFest](https://emberfest.eu/) | October 12-13, 2017 | | Berlin, Germany |
+| [Empire Conf](http://2017.empireconf.org/) | October 12-13, 2017 | | New York, NY, USA |
 | [RuhrJS](https://ruhrjs.de/) | October 14-15, 2017 | | Bochum, Germany |
 | [International JavaScript Conference](https://javascript-conference.com/en) | October 23-27, 2017 | | Munich, Germany |
 | [ReactiveConf](https://reactiveconf.com/) | October 25-27, 2017 | | Bratislava, Slovakia |


### PR DESCRIPTION
Empire Conf is a JavaScript and Node conference held in New York, NY, USA on October 12-13, 2017.